### PR TITLE
Fix wrong property names in doc

### DIFF
--- a/docs/math.md
+++ b/docs/math.md
@@ -16,9 +16,9 @@ You can manipulate datetime by using `add` or `substract`.
 - month
 - day
 - hour
-- minutes
-- seconds
-- milliseconds
+- minute
+- second
+- millisecond
 - quarter
 - weeks
 

--- a/docs/math.md
+++ b/docs/math.md
@@ -25,7 +25,7 @@ You can manipulate datetime by using `add` or `substract`.
 ```typescript
 const dt = datetime("2021-08-21:13:30:00"); // { year: 2021, month: 8, day: 21, hour: 13, minute: 30, second: 0, millisecond: 0, }
 
-dt.add({ year: 1 }).substract({ month: 2 }); // { year: 2022, month: 6, day: 21, hour: 13, minute: 30, second: 0, millisecond: 0, }
+dt.add({ year: 1, second: 10 }).substract({ month: 2, minute: 5 }); // { year: 2022, month: 6, day: 21, hour: 13, minute: 25, second: 10, millisecond: 0, }
 ```
 
 ## start and end


### PR DESCRIPTION
I just discovered that some properties are wrongly postfixed with `s` in the documentation.  Passing `minutes` for instance to `add` method would lead to a type error. 
So this PR fixes these typos, and also adds a little more complex example to show how it works.