### PR TITLE
docs: document parse behavior with non-format strings

### DIFF
--- a/docs/parse.md
+++ b/docs/parse.md
@@ -58,6 +58,12 @@ datetime().parse("2021 лютий 03", "YYYY MMMM dd", { locale: "uk" });
 | Z      | offset with colon                         | +03:00  |
 | ZZ     | short offset                              | +0300   |
 
+Non-format characters should be wrapped in single quotes when parsing, e.g.
+
+```typescript
+datetime().parse("2021-08-04T12:54:00Z", "YYYY-MM-dd'T'HH:mm:ssZ");
+```
+
 ## Unix Timestamp
 
 Ptera supports milliseconds Unix Timestamp.


### PR DESCRIPTION
I came across this behavior while using ptera to parse ISO strings without milliseconds. It's clear from the tests that this is the intended behavior, but I didn't notice this documented anywhere, so this PR updates the docs to cover the behavior of `parse` when non-format strings are in play.

Alternatively, the parse function could be updated to only handle format strings. A test to confirm the behavior can be added by applying this diff

```diff
diff --git a/parse_date_test.ts b/parse_date_test.ts
index a6729e5..0a64d2e 100644
--- a/parse_date_test.ts
+++ b/parse_date_test.ts
@@ -259,6 +259,21 @@ Deno.test("parseDateStr valid", () => {
         locale: "en",
       },
     },
+    {
+      dateStr: "2021-01-12T01:02:03Z",
+      format: "YYYY-MM-ddTHH:mm:ssZ",
+      expected: {
+        year: 2021,
+        month: 1,
+        day: 12,
+        hour: 1,
+        minute: 2,
+        second: 3,
+        millisecond: 0,
+        offsetMillisec: 0,
+        locale: "en",
+      },
+    },
   ];
   tests.forEach((t) => {
     assertEquals(parseDateStr(t.dateStr, t.format), t.expected);
```